### PR TITLE
フォトライブラリーとカメラを利用するため、iOS10以降のプライバシーポリシーに対応。

### DIFF
--- a/Xamarin_Emotion_Sample/Xamarin_Emotion_Sample.iOS/Info.plist
+++ b/Xamarin_Emotion_Sample/Xamarin_Emotion_Sample.iOS/Info.plist
@@ -48,5 +48,9 @@
     </array>
     <key>UILaunchStoryboardName</key>
     <string>LaunchScreen</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>This app accesses the photo library to analyze facial expressions.</string>
+    <key>NSCameraUsageDescription</key>
+    <string>This app accesses the camera to analyze facial expressions.</string>
   </dict>
 </plist>


### PR DESCRIPTION
iOS10以降の場合、info.plistにこの宣言がないと動作しないので追記しました。

![img_7118](https://user-images.githubusercontent.com/21341577/29257143-874efa12-80ea-11e7-9cfa-8b8147886371.PNG)
